### PR TITLE
O2 Insight Pro support, CLI options, timestamp offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__
+build/
+*.egg-info/
+venv/

--- a/FuzzyDateTimeParser.py
+++ b/FuzzyDateTimeParser.py
@@ -35,6 +35,7 @@ import locale
 import os
 import re
 
+
 class FuzzyDateTimeParser:
     # Formats to try for parsing a date and a time
     date_formats = []
@@ -47,18 +48,28 @@ class FuzzyDateTimeParser:
     @staticmethod
     def init():
         """Initialize the array of date formats for parsing
-:was
-        Use `locale.nl_langinfo(locale.D_FMT)` to see if the day is first,
-        decide if "%d %m %Y" and "%d %m %y" comes first in the list, or
-        "%m %d %Y" and "%m %d %y" do. Also put the year-month-day format
-        in the list.
+        :was
+                Use `locale.nl_langinfo(locale.D_FMT)` to see if the day is first,
+                decide if "%d %m %Y" and "%d %m %y" comes first in the list, or
+                "%m %d %Y" and "%m %d %y" do. Also put the year-month-day format
+                in the list.
         """
         if FuzzyDateTimeParser.is_day_first(locale.nl_langinfo(locale.D_FMT)):
             FuzzyDateTimeParser.date_formats = [
-                "%d %m %Y", "%d %m %y", "%m %d %Y", "%m %d %y", "%Y %m %d"]
+                "%d %m %Y",
+                "%d %m %y",
+                "%m %d %Y",
+                "%m %d %y",
+                "%Y %m %d",
+            ]
         else:
             FuzzyDateTimeParser.date_formats = [
-                "%m %d %Y", "%m %d %y", "%Y %m %d", "%d %m %Y", "%d %m %y"]
+                "%m %d %Y",
+                "%m %d %y",
+                "%Y %m %d",
+                "%d %m %Y",
+                "%d %m %y",
+            ]
 
     @staticmethod
     def is_day_first(d_fmt):
@@ -71,9 +82,9 @@ class FuzzyDateTimeParser:
             True if the day comes before the month in the date string
         """
         for ch in d_fmt:
-            if ch == 'd' or ch == 'e':
+            if ch == "d" or ch == "e":
                 return True
-            if ch == 'm':
+            if ch == "m":
                 return False
 
         # Probably should have already found d/e or m, so IDK?
@@ -141,7 +152,9 @@ class FuzzyDateTimeParser:
                 d = datetime.datetime.strptime(simp, fmt)
                 # If we got here, parsing was successful, so move this format
                 # to thefront of the list and then return the parsed value
-                FuzzyDateTimeParser.date_formats.insert(0, FuzzyDateTimeParser.date_formats.pop(idx))
+                FuzzyDateTimeParser.date_formats.insert(
+                    0, FuzzyDateTimeParser.date_formats.pop(idx)
+                )
                 return d
             except ValueError:
                 pass
@@ -164,7 +177,9 @@ class FuzzyDateTimeParser:
         # First try to parse with user-supplied time format
         try:
             if FuzzyDateTimeParser.t_fmt is not None:
-                return datetime.datetime.strptime(time_str, FuzzyDateTimeParser.t_fmt).time()
+                return datetime.datetime.strptime(
+                    time_str, FuzzyDateTimeParser.t_fmt
+                ).time()
         except ValueError:
             pass
 
@@ -173,7 +188,9 @@ class FuzzyDateTimeParser:
         for idx, fmt in enumerate(FuzzyDateTimeParser.time_formats):
             try:
                 t = datetime.datetime.strptime(simp, fmt).time()
-                FuzzyDateTimeParser.time_formats.insert(0, FuzzyDateTimeParser.time_formats.pop(idx))
+                FuzzyDateTimeParser.time_formats.insert(
+                    0, FuzzyDateTimeParser.time_formats.pop(idx)
+                )
                 return t
             except ValueError:
                 pass

--- a/FuzzyDateTimeParser.py
+++ b/FuzzyDateTimeParser.py
@@ -105,7 +105,7 @@ class FuzzyDateTimeParser:
             the string with any non-digits replaced by a single space, no
             leading or trailing spaces, either
         """
-        return re.sub("\D+", " ", date_str).strip()
+        return re.sub(r"\D+", " ", date_str).strip()
 
     @staticmethod
     def simplify_time_string(time_str):
@@ -118,7 +118,7 @@ class FuzzyDateTimeParser:
             the string with any non-digits replaced by a single space, with any AM/PM
             preserved, no leading or trailing spaces, either
         """
-        return re.sub("[^APMapm\d]+", " ", time_str).strip()
+        return re.sub(r"[^APMapm\d]+", " ", time_str).strip()
 
     @staticmethod
     def parse_date(date_str):

--- a/MedViewFileWriter.py
+++ b/MedViewFileWriter.py
@@ -15,7 +15,7 @@ Usage example:
 
 ```
 with open(output_filename, "wb") as datfile:
-    with MedViewFileWriter.MedViewFileWriter(datfile) as dat:
+    with MedViewFileWriter.MedViewFileWriter(datfile, timeOffset) as dat:
         # ...
         # [magic happens here, and now ts is a date and time,
         # and o2 and bpm have valid values]
@@ -54,15 +54,18 @@ https://www.apneaboard.com/forums/Thread-python-file-converter-for-EMAY-sleep-pu
 import logging
 import struct
 import unittest
+import datetime
 
 
 class MedViewFileWriter:
-    def __init__(self, datfile):
+    def __init__(self, datfile, timeOffset=0):
         # Keep track of the number of records written to output file.
         self.records = 0
         # File handle for the DAT file
         self.datfile = datfile
         self.write_dat_header()
+        # optional timestamp correction offset
+        self.timeOffset = timeOffset
 
     def __del__(self):
         self.update_dat_header()
@@ -126,6 +129,9 @@ class MedViewFileWriter:
         except:
             logging.error(f"Invalid BPM value: '{bpm}'")
             return
+
+        # Apply the time offset
+        timestamp += datetime.timedelta(seconds=self.timeOffset)
 
         try:
             line = struct.pack(

--- a/O2InsightProReader.py
+++ b/O2InsightProReader.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+Read data files in CVS format produced by Wellue's O2 Insight Pro.
+
+This has been tested with data from Wellue's O2Ring Oximeter.
+
+The first row is the header:
+    Time,SpO2(%),Pulse Rate(bpm),Motion,SpO2 Reminder,PR Reminder
+        Time is in the format HH:MM:SS{AM|PM} Month Day, Year
+        HH is 12-hour format
+        This appears to be independent of any OS settings for date/time formats.
+
+    SpO2 is an integer in percent (0-100)
+
+    Pulse Rate is an integer in beats per minute
+
+    Motion and the Reminder fields are not used
+"""
+
+import csv
+import datetime
+import logging
+
+
+class O2InsightProReader:
+    # only have "May" data from the app at this point
+    # maybe it's the full month name or the abbreviation...
+    timeFormats = ["%I:%M:%S%p %B %d, %Y", "%I:%M:%S%p %b %d, %Y"]
+
+    def __init__(self, csvfile):
+        self.reader = csv.DictReader(csvfile)
+
+        if self.reader.fieldnames[:6] != [
+            "Time",
+            "SpO2(%)",
+            "Pulse Rate(bpm)",
+            "Motion",
+            "SpO2 Reminder",
+            "PR Reminder",
+        ]:
+            logging.error(
+                f"CSV file does not appear to be a valid O2 Insight Pro CSV file"
+            )
+            self.reader = None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        while True:
+            try:
+                row = next(self.reader)
+            except TypeError:
+                raise StopIteration
+
+            for timeFormat in self.timeFormats:
+                try:
+                    timestamp = datetime.datetime.strptime(row["Time"], timeFormat)
+                    break
+                except ValueError:
+                    pass
+            else:
+                logging.error(
+                    f"Invalid date/time \"{row['Time']}\" on line {self.reader.line_num}"
+                )
+                raise StopIteration
+
+            try:
+                o2 = int(row["SpO2(%)"])
+            except ValueError:
+                logging.warning(
+                    f"Empty/invalid SpO2(%) value line {self.reader.line_num}"
+                )
+                o2 = None
+            except TypeError:
+                logging.error(f"Missing SpO2(%) value line {self.reader.line_num}")
+                raise StopIteration
+
+            try:
+                bpm = int(row["Pulse Rate(bpm)"])
+            except ValueError:
+                logging.warning(
+                    f"Empty/invalid Pulse Rate(bpm) value line {self.reader.line_num}"
+                )
+                bpm = None
+            except TypeError:
+                logging.error(
+                    f"Missing Pulse Rate(bpm) value line {self.reader.line_num}"
+                )
+                raise StopIteration
+
+            # these records seem to exist when the device is finished with a collection
+            if o2 == 255 and bpm == 65535:
+                continue
+            return (timestamp, o2, bpm)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # emay2medview
 
-Convert a CSV file from an EMAY\[TM\] SleepO2\[TM\] pulse oximeter into ChoiceMMed\[TM\]'s MedView\[TM\] (.DAT) format, which can be imported into [OSCAR](https://www.sleepfiles.com/OSCAR/), the Open Source CPAP Analysis Reporter.
+Convert a CSV file from an EMAY&trade; SleepO2&trade; or Wellue&trade; O2Ring&trade; pulse oximeter into ChoiceMMed&trade;'s MedView&trade; (.DAT) format, which can be imported into [OSCAR](https://www.sleepfiles.com/OSCAR/), the Open Source CPAP Analysis Reporter.
 
 ## Install
 
-Requires Python 3.6 or newer. The default Python installation should have all required packages.
+Requires Python 3.6 or newer.
 
 Install the code either by cloning the repo or downloading a ZIP.
 
 ### Clone the `git` repository
 
-```
-$ git clone https://github.com/ElectricalPaul/emay2medview.git
+```shell
+git clone https://github.com/ElectricalPaul/emay2medview.git
 ```
 
 ### Download and DIY
@@ -20,6 +20,8 @@ $ git clone https://github.com/ElectricalPaul/emay2medview.git
 1. Click on "Clone or Download"
 1. Click on "Download ZIP" and save the ZIP file
 1. Unzip the file
+1. _Optional (recommended):_ create a virtual environment: `virtualenv venv && source venv/bin/activate`
+1. Install the package, e.g. `pip install <zipfile>` or `cd <extracted zip> && pip install .`
 1. ???
 1. ~Profit!~ Convert data files!
 
@@ -33,13 +35,21 @@ $ git clone https://github.com/ElectricalPaul/emay2medview.git
     1. Select "Share"
     1. Save the file to Google Drive or iCloud, or email it to yourself
     1. Transfer the file from the cloud or email to your local system, e.g. `Downloads`
-1. Run `emay2medview.py` from the shell/Terminal/Command Prompt and give it the name of the CSV file, e.g. `python3 ./emay2medview.pt 20240226.csv`
+1. Run `emay2medview` from the shell/Terminal/Command Prompt and give it the name of the CSV file, e.g. `emay2medview 20240226.csv`
 1. Import the resulting `DAT` file (e.g. `20240226.DAT`) into OSCAR with the Oximetry Wizard
+
+### Options
+
+The only required argument is the input CSV filename in EMAY format.
+
+Optionally, specify:
+
+* `--output-file`, `-o` Path to a custom filename for the MedView output data file. If unspecified, the output file will use the CSV's filename and location but with a _.dat_ extension.
+* `--input-format`, `-f` Data format of the input CSV file. Defaults to `emay` but `o2insight` may be specified for O2Ring data exported from O2 Insight Pro. You may also invoke the script using the `o2insight2medview` command in lieu of specifying this option.
 
 ## Future Plans
 
 * Add a GUI, possibly with `tkinter` directly, or [PySimpleGUI](https://realpython.com/pysimplegui-python/)
-* Make the code installable with `pip3`
 * Make a standalone program using [PyInstaller](https://pyinstaller.org/en/stable/)
 
 ## Notes
@@ -56,3 +66,5 @@ and is used by permission.
 EMAY and SleepO2 are trademarks of EMAY (HK) Limited.
 
 ChoiceMMed and MedView are trademarks of Beijing Choice Electronic Tech Co.
+
+O2Ring, O2 Insight Pro, and Wellue are trademarks of Shenzhen Viatom Technology Co., Ltd. (Viatom).

--- a/emay2medview.py
+++ b/emay2medview.py
@@ -18,6 +18,7 @@ import EmayFileReader
 import O2InsightProReader
 import MedViewFileWriter
 import click
+from tqdm import tqdm
 
 
 @click.command()
@@ -61,13 +62,31 @@ def main(**params):
             csv = EmayFileReader.EmayFileReader(csvfile)
 
         with open(output_filename, "wb") as datfile:
-            with MedViewFileWriter.MedViewFileWriter(datfile, timeOffset) as medview:
+            with MedViewFileWriter.MedViewFileWriter(
+                datfile, timeOffset
+            ) as medview, progress(description="Processing records") as bar:
                 for rec in csv:
                     if not rec[1] or not rec[2]:
                         logging.info(f"Missing data for time {rec[0]}, skip")
+                        bar.update()
                         continue
 
                     medview.write_record(rec[0], rec[1], rec[2])
+                    bar.update()
+
+
+def progress(description=None, max=0, unit=None, color=None, position=None, leave=True):
+    if unit is None:
+        unit = " records"
+    else:
+        unit = " {unit}".format(unit=unit)
+
+    bar = tqdm(unit=unit, total=max, colour=color, position=position, leave=leave)
+
+    if description is not None:
+        bar.set_description(description)
+
+    return bar
 
 
 def o2insight2medview():

--- a/emay2medview.py
+++ b/emay2medview.py
@@ -36,9 +36,16 @@ import click
     default="emay",
     help="CSV file data format",
 )
+@click.option(
+    "--time-offset",
+    type=click.INT,
+    default=0,
+    help="Adjust times in the output data by this many seconds (positive or negative)",
+)
 def main(**params):
     input_filename = params["csv"]
     input_format = params["input_format"]
+    timeOffset = params["time_offset"]
 
     if params["output_file"] is None:
         basename, _ = os.path.splitext(input_filename)
@@ -54,7 +61,7 @@ def main(**params):
             csv = EmayFileReader.EmayFileReader(csvfile)
 
         with open(output_filename, "wb") as datfile:
-            with MedViewFileWriter.MedViewFileWriter(datfile) as medview:
+            with MedViewFileWriter.MedViewFileWriter(datfile, timeOffset) as medview:
                 for rec in csv:
                     if not rec[1] or not rec[2]:
                         logging.info(f"Missing data for time {rec[0]}, skip")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from setuptools import setup
+
+
+setup(
+    name="emay2medview",
+    version="0.0.0",
+    py_modules=[
+        "emay2medview",
+        "EmayFileReader",
+        "O2InsightProReader",
+        "MedViewFileWriter",
+        "FuzzyDateTimeParser",
+    ],
+    install_requires=[
+        "Click",
+        "click-option-group",
+    ],
+    entry_points={
+        "console_scripts": [
+            "emay2medview=emay2medview:main",
+            "o2insight2medview=emay2medview:o2insight2medview",
+        ]
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     install_requires=[
         "Click",
         "click-option-group",
+        "tqdm",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Primary goal: add support for Wellue's O2Ring oximeter.

- The CSV data format from O2 Insight Pro is slightly different from EMAY's.

In allowing for the input data format to be specified (`--input-format`), introduced CLI argument support with Click and a setup.py file to install with `pip` and put the `emay2medview` (and the newly-added `o2insight2medview`) commands in the python shell environment's PATH.

This itself further facilitated specifying these optional CLI arguments:

- Custom output .dat file path/name (`--output-file`)
- Timestamp corrective offset (`--time-offset`) to shift the time by a specified number of seconds in either direction. In my case, the data is off from correlated data in OSCAR by 3600 seconds because one device seems to be doing a DST conversion inappropriately.